### PR TITLE
Updated to ndarray 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 image = { version = "0.23.2", default-features = false }
-ndarray = { version = "0.13.0", default-features = false }
+ndarray = { version = "0.14.0", default-features = false }
 
 [dev-dependencies]
 structopt = "0.3.12"


### PR DESCRIPTION
Updated to ndarray 0.14.0 to ensure compatibility with newest version. No tests to run.